### PR TITLE
directory change for Dockerfile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,20 +135,22 @@ where:
 
 **Fastest way to run SANTé is to build docker image using the given dockerfile**
 
-Make sure you have the index in the project as instructed above.
+Make sure you have created the index in the project as instructed above.
 
 1) Building the Docker Image:
-```
-docker build -t sante .
-```
-
-2) To run the docker image along with the specified ```index``` replacing ```YOUR_INDEX_GOES_HERE``` by your index path, here is the command:
 
 ```
-docker run -p7070:7070 -e index=YOUR_INDEX_GOES_HERE sante
+docker build -t sante/smile -f sante.smile/Dockerfile .   
+```
+
+2) To run the docker image along with the specified ```index```, here is the command:
+
+```
+docker run -p7070:7070 -e index=/sante/<index-name> sante/smile
 ```
 
 After running the image, the application is exposed at ```http://localhost:7070```
+
 
 **Alternative way to run SANTé**
 

--- a/sante.smile/Dockerfile
+++ b/sante.smile/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /sante
 
 WORKDIR /sante
 
-COPY . .
+COPY ../.. .
 
 RUN mvn clean install
 


### PR DESCRIPTION
This closes the issue #14 and #15 

UPDATE : 

[X] - Moved to smile directory
[X] - Renamed the image as "sante/smile"
[X] - Updated doc

1) Building the Docker Image:
```
docker build -t sante/smile -f sante.smile/Dockerfile .   
```

2) To run the docker image along with the specified ```index```, here is the command:

```
docker run -p7070:7070 -e index=/sante/<index-name> sante/smile
```

After running the image, the application is exposed at ```http://localhost:7070```