### PR TITLE
volume mount added to smile dockerfile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ docker build -t sante/smile -f sante.smile/Dockerfile .
 2) To run the docker image along with the specified ```index```, here is the command:
 
 ```
-docker run -p7070:7070 -e index=/sante/<index-name> sante/smile
+docker run -p 7070:7070 -v <YOUR INDEX PATH>:/index -itd sante/smile
 ```
 
 After running the image, the application is exposed at ```http://localhost:7070```

--- a/sante.smile/Dockerfile
+++ b/sante.smile/Dockerfile
@@ -14,11 +14,9 @@ FROM gcr.io/distroless/java17-debian11
 
 COPY --from=build /sante/sante.smile/target /sante/sante.smile
 
-COPY --from=build /sante/foaf_kg /sante/foaf_kg
-
 WORKDIR /sante/sante.smile
 
-ENTRYPOINT ["java","-jar","-Dsante.index.path=${index}","sante.smile-2.5.3.war"]
+ENTRYPOINT ["java","-jar","-Dsante.index.path=/index","sante.smile-2.5.3.war"]
 
 # Make port 7070 available to the world outside this container
 EXPOSE 7070


### PR DESCRIPTION
Resolves Issue #23 

1) Building the Docker Image:

```
docker build -t sante/smile -f sante.smile/Dockerfile .   
```

2) To run the docker image along with the specified ```index```, here is the command:

```
docker run -p 7070:7070 -v <YOUR INDEX PATH>:/index -itd sante/smile
```

After running the image, the application is exposed at ```http://localhost:7070```